### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ "*" ]
-#  pull_request:
-#    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
 
 jobs:
   upload-coverage-reports:

--- a/.github/workflows/kotlin-jvm-ci.yml
+++ b/.github/workflows/kotlin-jvm-ci.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: ["*"]
-#  pull_request:
-#    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
 
 jobs:
   test-and-check:


### PR DESCRIPTION
This should enable CI for the pull requests created by Copilot on whose commits CI is not run.