### PR TITLE
Refine The KDoc for `JdbcTransactionExposedTransactionProvider`

### DIFF
--- a/core/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/StatementPreparationExposedTransactionProvider.kt
+++ b/core/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/StatementPreparationExposedTransactionProvider.kt
@@ -1,5 +1,6 @@
 package com.huanshankeji.exposedvertxsqlclient
 
+import io.vertx.core.Verticle
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.transactions.withThreadLocalTransaction
 import org.jetbrains.exposed.v1.jdbc.Database

--- a/core/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/StatementPreparationExposedTransactionProvider.kt
+++ b/core/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/StatementPreparationExposedTransactionProvider.kt
@@ -60,26 +60,25 @@ class DatabaseExposedTransactionProvider(
 }
 
 /**
- * A [StatementPreparationExposedTransactionProvider] that reuses a single [JdbcTransaction] for all SQL preparation calls.
+ * A [StatementPreparationExposedTransactionProvider] that reuses/shares a possibly closed [JdbcTransaction] for SQL preparation calls.
  *
  * This approach provides better performance by avoiding the overhead of creating a new transaction
- * for each SQL preparation call. The transaction is created once and reused across multiple SQL preparations.
+ * for each SQL preparation call. The transaction is created once, possibly closed, and reused/shared across multiple SQL preparations.
+ *
+ * **Implementation note:** The transaction instance members needed for SQL preparation remain usable even after
+ * the underlying connection is not actively used.
  *
  * **Thread safety:** This provider holds a single [JdbcTransaction] instance with internal mutable state and is
  * not designed for concurrent use from multiple threads. Calling [statementPreparationExposedTransaction] from
- * multiple threads at the same time on the same provider instance may lead to data races or inconsistent
- * internal state. If you need to prepare statements concurrently, create a separate
- * [JdbcTransactionExposedTransactionProvider] (and underlying [JdbcTransaction]) per thread or ensure external
- * synchronization so that only one thread uses a given instance at a time.
+ * multiple threads at the same time on the same provider instance may lead to inconsistent internal state.
+ * If you need to prepare statements concurrently, create a separate
+ * [JdbcTransactionExposedTransactionProvider] (and underlying [JdbcTransaction]) per thread/[Verticle].
  *
  * **Read-only behavior:** This provider is intended to be used only for SQL statement preparation (e.g., statement
- * building and `prepareSQL`) and must not be used to execute DML/DDL statements that modify the database.
+ * building and `prepareSQL`) and the transaction must not be used to execute DML/DDL statements that modify the database.
  * The underlying [JdbcTransaction] may still accumulate internal state (such as caches or counters) while being
  * used for SQL generation, so it is not strictly read-only in terms of object immutability, but it should be used
  * in a way that does not perform database writes.
- *
- * **Note:** The transaction instance members needed for SQL preparation remain usable even after
- * the underlying connection is not actively used.
  *
  * @param jdbcTransaction the [JdbcTransaction] to use for SQL statement preparation
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined in-code documentation to clarify reuse of potentially-closed transactions for statement preparation and added an implementation note on member usability after the underlying connection is inactive.
  * Tightened thread-safety guidance: not safe for concurrent use on the same instance—use a separate provider per thread/Verticle.
  * Clarified read-only expectations: only for statement preparation, not for database-modifying operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/huanshankeji/exposed-vertx-sql-client/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->