### PR TITLE
Add :testcontainers module; deprecate :integrated container helpers

### DIFF
--- a/buildSrc/src/main/kotlin/VersionsAndDependencies.kt
+++ b/buildSrc/src/main/kotlin/VersionsAndDependencies.kt
@@ -2,12 +2,12 @@ import com.huanshankeji.CommonDependencies
 import com.huanshankeji.CommonGradleClasspathDependencies
 import com.huanshankeji.CommonVersions
 
-val projectVersion = "0.8.2-SNAPSHOT"
+val projectVersion = "0.9.0-SNAPSHOT"
 
 // don't use a snapshot version in a main branch
 // Note that there is another Exposed version in the version catalog
 val commonVersions =
-    CommonVersions(kotlinCommon = "0.7.0", exposed = "1.1.1", testcontainers = "2.0.4", vertx = "5.0.10")
+    CommonVersions(kotlinCommon = "0.8.0-SNAPSHOT", exposed = "1.1.1", testcontainers = "2.0.4", vertx = "5.0.10")
 val commonDependencies = CommonDependencies(commonVersions)
 val commonGradleClasspathDependencies = CommonGradleClasspathDependencies(commonVersions)
 

--- a/integrated/build.gradle.kts
+++ b/integrated/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation(cpnProject(project, ":crud"))
     implementation("com.huanshankeji:exposed-gadt-mapping:${DependencyVersions.exposedGadtMapping}")
     implementation(cpnProject(project, ":crud-with-mapper"))
+    // Kept for backward compatibility of the deprecated `Containers.kt` shim; delete with the shim in a future release.
+    api(cpnProject(project, ":testcontainers"))
 
     with(commonDependencies.testcontainers) {
         implementation(platformBom())

--- a/integrated/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/integrated/Containers.kt
+++ b/integrated/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/integrated/Containers.kt
@@ -1,16 +1,26 @@
+/*
+All helpers here have moved:
+- EVSC-specific helpers (`connectionConfig()`, `exposedDatabaseConnect()`, `hikariConfig()`, `hikariDataSource()`)
+  → `com.huanshankeji.exposedvertxsqlclient.testcontainers` (`exposed-vertx-sql-client-testcontainers` module).
+- Generic container factories (`LatestPostgreSQLContainer()`, etc.)
+  → `com.huanshankeji.testcontainers` (`com.huanshankeji:kotlin-common-testcontainers`).
+
+This file is kept as a deprecated forwarding shim and will be removed in a future release.
+*/
+
+@file:Suppress("DEPRECATION")
 @file:OptIn(ExperimentalEvscApi::class)
 
 package com.huanshankeji.exposedvertxsqlclient.integrated
 
 import com.huanshankeji.exposedvertxsqlclient.ConnectionConfig
 import com.huanshankeji.exposedvertxsqlclient.ExperimentalEvscApi
-import com.huanshankeji.exposedvertxsqlclient.jdbc.postgresqlJdbcUrl
-import com.huanshankeji.exposedvertxsqlclient.mssql.exposed.exposedDatabaseConnectMssql
-import com.huanshankeji.exposedvertxsqlclient.mysql.exposed.exposedDatabaseConnectMysql
-import com.huanshankeji.exposedvertxsqlclient.oracle.exposed.exposedDatabaseConnectOracle
-import com.huanshankeji.exposedvertxsqlclient.postgresql.exposed.exposedDatabaseConnectPostgresql
+import com.huanshankeji.exposedvertxsqlclient.testcontainers.connectionConfig as newConnectionConfig
+import com.huanshankeji.exposedvertxsqlclient.testcontainers.exposedDatabaseConnect as newExposedDatabaseConnect
+import com.huanshankeji.exposedvertxsqlclient.testcontainers.hikariConfig as newHikariConfig
+import com.huanshankeji.exposedvertxsqlclient.testcontainers.hikariDataSource as newHikariDataSource
+import com.huanshankeji.testcontainers.LatestPostgreSQLContainer as NewLatestPostgreSQLContainer
 import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.mssqlserver.MSSQLServerContainer
@@ -19,57 +29,71 @@ import org.testcontainers.oracle.OracleContainer
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
-fun JdbcDatabaseContainer<*>.connectionConfig() =
-    ConnectionConfig.Socket(host, firstMappedPort, username, password, databaseName)
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("connectionConfig()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.connectionConfig")
+)
+fun JdbcDatabaseContainer<*>.connectionConfig() = newConnectionConfig()
 
 
 // https://testcontainers.com/modules/postgresql/
-fun LatestPostgreSQLContainer(): PostgreSQLContainer =
-    PostgreSQLContainer(DockerImageName.parse("postgres:latest"))
+@Deprecated(
+    "Moved to `com.huanshankeji:kotlin-common-testcontainers` as `com.huanshankeji.testcontainers.LatestPostgreSQLContainer`.",
+    ReplaceWith("LatestPostgreSQLContainer()", "com.huanshankeji.testcontainers.LatestPostgreSQLContainer")
+)
+fun LatestPostgreSQLContainer(): PostgreSQLContainer = NewLatestPostgreSQLContainer()
 
-// TODO consider deprecating these functions and recommending the caller to call `connectionConfig()` and then call the extensions function on `ConnectionConfig.Socket` instead
-fun PostgreSQLContainer.exposedDatabaseConnect(): Database =
-    connectionConfig().exposedDatabaseConnectPostgresql()
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("exposedDatabaseConnect()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.exposedDatabaseConnect")
+)
+fun PostgreSQLContainer.exposedDatabaseConnect(): Database = newExposedDatabaseConnect()
 
-// move to the `postgresql` module if it's proved useful
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("hikariConfig(maximumPoolSize, extraConfig)", "com.huanshankeji.exposedvertxsqlclient.testcontainers.hikariConfig")
+)
 fun ConnectionConfig.Socket.hikariConfig(
     maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {},
-): HikariConfig =
-    HikariConfig().apply {
-        jdbcUrl = postgresqlJdbcUrl()
-        driverClassName = "org.postgresql.Driver" // TODO extract
-        username = user
-        password = this@hikariConfig.password
-        this.maximumPoolSize = maximumPoolSize
-        // configurations for SQL preparation for Vert.x SQL Clients
-        isReadOnly = true
-        transactionIsolation = "TRANSACTION_READ_UNCOMMITTED"
-        extraConfig()
-    }
+): HikariConfig = newHikariConfig(maximumPoolSize, extraConfig)
 
-fun PostgreSQLContainer.hikariConfig(maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {}): HikariConfig {
-    val connectionConfig = connectionConfig()
-    return connectionConfig.hikariConfig(maximumPoolSize, extraConfig)
-}
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("hikariConfig(maximumPoolSize, extraConfig)", "com.huanshankeji.exposedvertxsqlclient.testcontainers.hikariConfig")
+)
+fun PostgreSQLContainer.hikariConfig(maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {}): HikariConfig =
+    newHikariConfig(maximumPoolSize, extraConfig)
 
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("hikariDataSource(maximumPoolSize, extraConfig)", "com.huanshankeji.exposedvertxsqlclient.testcontainers.hikariDataSource")
+)
 fun PostgreSQLContainer.hikariDataSource(maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {}) =
-    HikariDataSource(hikariConfig(maximumPoolSize, extraConfig))
+    newHikariDataSource(maximumPoolSize, extraConfig)
 
 
 // https://testcontainers.com/modules/mysql/
+@Deprecated("Will likely be moved to `kotlin-common-testcontainers` in the future.")
 fun LatestMySQLContainer(): MySQLContainer =
     MySQLContainer(DockerImageName.parse("mysql:latest"))
 
-fun MySQLContainer.exposedDatabaseConnect(): Database =
-    connectionConfig().exposedDatabaseConnectMysql()
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("exposedDatabaseConnect()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.exposedDatabaseConnect")
+)
+fun MySQLContainer.exposedDatabaseConnect(): Database = newExposedDatabaseConnect()
 
 
 // https://testcontainers.com/modules/oracle-free/
+@Deprecated("Will likely be moved to `kotlin-common-testcontainers` in the future.")
 fun LatestOracleContainer(): OracleContainer =
     OracleContainer(DockerImageName.parse("gvenzl/oracle-free:latest"))
 
-fun OracleContainer.exposedDatabaseConnect(): Database =
-    connectionConfig().exposedDatabaseConnectOracle()
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("exposedDatabaseConnect()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.exposedDatabaseConnect")
+)
+fun OracleContainer.exposedDatabaseConnect(): Database = newExposedDatabaseConnect()
 
 
 /*
@@ -77,13 +101,19 @@ https://testcontainers.com/modules/mssql/
 https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker
 https://hub.docker.com/r/microsoft/mssql-server
 */
+@Deprecated("Will likely be moved to `kotlin-common-testcontainers` in the future.")
 fun LatestMssqlContainer(): MSSQLServerContainer =
     MSSQLServerContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2022-latest"))
         .acceptLicense()
 
-// `MSSQLServerContainer` doesn't support `getDatabaseName()`, so we need a specific implementation.
-fun MSSQLServerContainer.connectionConfig() =
-    ConnectionConfig.Socket(host, firstMappedPort, username, password, "master")
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("connectionConfig()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.connectionConfig")
+)
+fun MSSQLServerContainer.connectionConfig() = newConnectionConfig()
 
-fun MSSQLServerContainer.exposedDatabaseConnect(): Database =
-    connectionConfig().exposedDatabaseConnectMssql()
+@Deprecated(
+    "Moved to `com.huanshankeji.exposedvertxsqlclient.testcontainers`.",
+    ReplaceWith("exposedDatabaseConnect()", "com.huanshankeji.exposedvertxsqlclient.testcontainers.exposedDatabaseConnect")
+)
+fun MSSQLServerContainer.exposedDatabaseConnect(): Database = newExposedDatabaseConnect()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ include("mysql")
 include("oracle")
 include("mssql")
 include("integrated")
+include("testcontainers")
 
 fun ProjectDescriptor.setProjectConcatenatedNames(prefix: String) {
     name = prefix + name

--- a/testcontainers/README.md
+++ b/testcontainers/README.md
@@ -1,0 +1,10 @@
+# EVSC Testcontainers Helpers
+
+EVSC-specific Testcontainers helpers: converting a `JdbcDatabaseContainer` to an
+EVSC `ConnectionConfig.Socket`, connecting Exposed `Database`s from containers,
+and HikariCP helpers built on top of EVSC's connection config.
+
+For generic, non-EVSC Testcontainers helpers (e.g. `LatestPostgreSQLContainer()`
+and `JdbcDatabaseContainer.hostAndPort()`), see the
+[`kotlin-common-testcontainers`](https://github.com/huanshankeji/kotlin-common/tree/main/testcontainers)
+module.

--- a/testcontainers/api/exposed-vertx-sql-client-testcontainers.api
+++ b/testcontainers/api/exposed-vertx-sql-client-testcontainers.api
@@ -1,0 +1,15 @@
+public final class com/huanshankeji/exposedvertxsqlclient/testcontainers/EvscContainersKt {
+	public static final fun connectionConfig (Lorg/testcontainers/containers/JdbcDatabaseContainer;)Lcom/huanshankeji/exposedvertxsqlclient/ConnectionConfig$Socket;
+	public static final fun connectionConfig (Lorg/testcontainers/mssqlserver/MSSQLServerContainer;)Lcom/huanshankeji/exposedvertxsqlclient/ConnectionConfig$Socket;
+	public static final fun exposedDatabaseConnect (Lorg/testcontainers/mssqlserver/MSSQLServerContainer;)Lorg/jetbrains/exposed/v1/jdbc/Database;
+	public static final fun exposedDatabaseConnect (Lorg/testcontainers/mysql/MySQLContainer;)Lorg/jetbrains/exposed/v1/jdbc/Database;
+	public static final fun exposedDatabaseConnect (Lorg/testcontainers/oracle/OracleContainer;)Lorg/jetbrains/exposed/v1/jdbc/Database;
+	public static final fun exposedDatabaseConnect (Lorg/testcontainers/postgresql/PostgreSQLContainer;)Lorg/jetbrains/exposed/v1/jdbc/Database;
+	public static final fun hikariConfig (Lcom/huanshankeji/exposedvertxsqlclient/ConnectionConfig$Socket;ILkotlin/jvm/functions/Function1;)Lcom/zaxxer/hikari/HikariConfig;
+	public static final fun hikariConfig (Lorg/testcontainers/postgresql/PostgreSQLContainer;ILkotlin/jvm/functions/Function1;)Lcom/zaxxer/hikari/HikariConfig;
+	public static synthetic fun hikariConfig$default (Lcom/huanshankeji/exposedvertxsqlclient/ConnectionConfig$Socket;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/zaxxer/hikari/HikariConfig;
+	public static synthetic fun hikariConfig$default (Lorg/testcontainers/postgresql/PostgreSQLContainer;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/zaxxer/hikari/HikariConfig;
+	public static final fun hikariDataSource (Lorg/testcontainers/postgresql/PostgreSQLContainer;ILkotlin/jvm/functions/Function1;)Lcom/zaxxer/hikari/HikariDataSource;
+	public static synthetic fun hikariDataSource$default (Lorg/testcontainers/postgresql/PostgreSQLContainer;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/zaxxer/hikari/HikariDataSource;
+}
+

--- a/testcontainers/build.gradle.kts
+++ b/testcontainers/build.gradle.kts
@@ -1,0 +1,26 @@
+import com.huanshankeji.cpnProject
+
+plugins {
+    `lib-conventions`
+}
+
+dependencies {
+    with(commonDependencies.vertx) { implementation(platformStackDepchain()) }
+    implementation(cpnProject(project, ":core"))
+    implementation(cpnProject(project, ":postgresql"))
+    implementation(cpnProject(project, ":mysql"))
+    implementation(cpnProject(project, ":oracle"))
+    implementation(cpnProject(project, ":mssql"))
+
+    api("com.huanshankeji:kotlin-common-testcontainers:${commonVersions.kotlinCommon}")
+
+    with(commonDependencies.testcontainers) {
+        api(platformBom())
+        api(testcontainersPostgresql)
+        api(moduleWithoutVersion("testcontainers-mysql"))
+        api(moduleWithoutVersion("testcontainers-oracle-free"))
+        api(moduleWithoutVersion("testcontainers-mssqlserver"))
+    }
+
+    implementation("com.zaxxer:HikariCP:${DependencyVersions.hikaricp}")
+}

--- a/testcontainers/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/testcontainers/EvscContainers.kt
+++ b/testcontainers/src/main/kotlin/com/huanshankeji/exposedvertxsqlclient/testcontainers/EvscContainers.kt
@@ -1,0 +1,69 @@
+@file:OptIn(ExperimentalEvscApi::class)
+
+package com.huanshankeji.exposedvertxsqlclient.testcontainers
+
+import com.huanshankeji.exposedvertxsqlclient.ConnectionConfig
+import com.huanshankeji.exposedvertxsqlclient.ExperimentalEvscApi
+import com.huanshankeji.exposedvertxsqlclient.jdbc.postgresqlJdbcUrl
+import com.huanshankeji.exposedvertxsqlclient.mssql.exposed.exposedDatabaseConnectMssql
+import com.huanshankeji.exposedvertxsqlclient.mysql.exposed.exposedDatabaseConnectMysql
+import com.huanshankeji.exposedvertxsqlclient.oracle.exposed.exposedDatabaseConnectOracle
+import com.huanshankeji.exposedvertxsqlclient.postgresql.exposed.exposedDatabaseConnectPostgresql
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.testcontainers.containers.JdbcDatabaseContainer
+import org.testcontainers.mssqlserver.MSSQLServerContainer
+import org.testcontainers.mysql.MySQLContainer
+import org.testcontainers.oracle.OracleContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
+
+/*
+EVSC-specific Testcontainers helpers.
+Generic, non-EVSC helpers (`LatestPostgreSQLContainer()`, `JdbcDatabaseContainer.hostAndPort()`, etc.)
+live in `com.huanshankeji:kotlin-common-testcontainers`.
+*/
+
+fun JdbcDatabaseContainer<*>.connectionConfig() =
+    ConnectionConfig.Socket(host, firstMappedPort, username, password, databaseName)
+
+// TODO consider deprecating these functions and recommending the caller to call `connectionConfig()` and then call the extensions function on `ConnectionConfig.Socket` instead
+fun PostgreSQLContainer.exposedDatabaseConnect(): Database =
+    connectionConfig().exposedDatabaseConnectPostgresql()
+
+// move to the `postgresql` module if it's proved useful
+fun ConnectionConfig.Socket.hikariConfig(
+    maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {},
+): HikariConfig =
+    HikariConfig().apply {
+        jdbcUrl = postgresqlJdbcUrl()
+        driverClassName = "org.postgresql.Driver" // TODO extract
+        username = user
+        password = this@hikariConfig.password
+        this.maximumPoolSize = maximumPoolSize
+        // configurations for SQL preparation for Vert.x SQL Clients
+        isReadOnly = true
+        transactionIsolation = "TRANSACTION_READ_UNCOMMITTED"
+        extraConfig()
+    }
+
+fun PostgreSQLContainer.hikariConfig(maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {}): HikariConfig {
+    val connectionConfig = connectionConfig()
+    return connectionConfig.hikariConfig(maximumPoolSize, extraConfig)
+}
+
+fun PostgreSQLContainer.hikariDataSource(maximumPoolSize: Int, extraConfig: HikariConfig.() -> Unit = {}) =
+    HikariDataSource(hikariConfig(maximumPoolSize, extraConfig))
+
+fun MySQLContainer.exposedDatabaseConnect(): Database =
+    connectionConfig().exposedDatabaseConnectMysql()
+
+fun OracleContainer.exposedDatabaseConnect(): Database =
+    connectionConfig().exposedDatabaseConnectOracle()
+
+// `MSSQLServerContainer` doesn't support `getDatabaseName()`, so we need a specific implementation.
+fun MSSQLServerContainer.connectionConfig() =
+    ConnectionConfig.Socket(host, firstMappedPort, username, password, "master")
+
+fun MSSQLServerContainer.exposedDatabaseConnect(): Database =
+    connectionConfig().exposedDatabaseConnectMssql()


### PR DESCRIPTION
Splits the reusable Testcontainers helpers out of `:integrated` into a dedicated `:testcontainers` module published as `com.huanshankeji:exposed-vertx-sql-client-testcontainers`. The previous helpers in `:integrated/Containers.kt` are now `@Deprecated` forwarders with proper `ReplaceWith` annotations.

What moved:
- **To this module** (`com.huanshankeji.exposedvertxsqlclient.testcontainers`):
  - `JdbcDatabaseContainer.connectionConfig()`
  - `PostgreSQLContainer.exposedDatabaseConnect()`, `MySQLContainer.exposedDatabaseConnect()`, `OracleContainer.exposedDatabaseConnect()`, `MSSQLServerContainer.exposedDatabaseConnect()`
  - `MSSQLServerContainer.connectionConfig()`
  - `ConnectionConfig.Socket.hikariConfig(...)`, `PostgreSQLContainer.hikariConfig(...)`, `PostgreSQLContainer.hikariDataSource(...)`
- **To `com.huanshankeji:kotlin-common-testcontainers`** (huanshankeji/kotlin-common#50):
  - `LatestPostgreSQLContainer()` factory

Version bumps:
- this project: `0.8.2-SNAPSHOT` → `0.9.0-SNAPSHOT`
- consumes `com.huanshankeji:kotlin-common:0.8.0-SNAPSHOT` (from huanshankeji/kotlin-common#50)

Depends on: huanshankeji/kotlin-common#50

Part of the stack for architecture-common issue [#88](https://github.com/huanshankeji/architecture-common/issues/88).