### PR TITLE
docs: add Cursor Cloud specific setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,40 @@
 See [Copilot instructions](.github/copilot-instructions.md) for this repository.
 
 Organization-wide standards and open-source library map: [@huanshankeji/.github general agent instructions](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md).
+
+## Cursor Cloud specific instructions
+
+This is a Kotlin JVM (Gradle) library. Standard build/lint/test commands are in
+[Copilot instructions](.github/copilot-instructions.md) (`./gradlew check`, `./gradlew apiCheck`,
+`./gradlew test`, `./gradlew publishToMavenLocal`). Notes below are the non-obvious Cloud caveats only.
+
+### JDK toolchain
+- Gradle requires a **JDK 11 toolchain** (`kotlin.jvmToolchain(11)`); CI also uses 17. JDK 11, 17 and 21
+  are installed on the VM. The default `java` on `PATH` is 21, which is fine — Gradle auto-detects the
+  JDK 11 toolchain from `/usr/lib/jvm`. No `JAVA_HOME` override is needed.
+
+### Docker / Testcontainers (integration tests)
+- `./gradlew test` / `check` run Kotest + Testcontainers integration tests that need a Docker daemon.
+- Docker is installed but is **not** a running service on boot. Start it once per session:
+  `sudo dockerd > /tmp/dockerd.log 2>&1 &` (it is configured for the `fuse-overlayfs` storage driver
+  with the containerd snapshotter disabled in `/etc/docker/daemon.json`; required for this VM).
+- Run Gradle with `sudo -E` (or as root) so it can reach `/var/run/docker.sock`.
+- Set `TESTCONTAINERS_RYUK_DISABLED=true`: the Ryuk cleanup image lives on Docker Hub whose blob CDN is
+  blocked here (see egress note), so leaving Ryuk enabled makes container startup fail.
+- Every `AllConfigurationsSpec` subclass eagerly starts **all four** DB containers (PostgreSQL, MySQL,
+  Oracle, MSSQL) in `beforeSpec`, so a single spec cannot be narrowed to one DB via Gradle `--tests`.
+
+### Egress limitation for container images (important)
+- Network egress is allowlist-based. Registry indexes are reachable but most image **blob CDNs are
+  blocked** (connection reset): Docker Hub blobs (`docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`)
+  and MCR blobs (`*.data.mcr.microsoft.com`). `public.ecr.aws` blobs **are** reachable.
+- Workaround for the two Docker Hub official images used by the tests — pull from the AWS ECR public
+  mirror and retag to the exact names Testcontainers expects:
+  - `docker pull public.ecr.aws/docker/library/postgres:latest && docker tag public.ecr.aws/docker/library/postgres:latest postgres:latest`
+  - `docker pull public.ecr.aws/docker/library/mysql:latest && docker tag public.ecr.aws/docker/library/mysql:latest mysql:latest`
+- With the two images above, PostgreSQL and MySQL integration tests run end-to-end.
+- `gvenzl/oracle-free:latest` (Oracle, Docker Hub community image) and `mcr.microsoft.com/mssql/server:2022-latest`
+  (MSSQL) have **no reachable source** under the current allowlist, so the full `./gradlew test` / `check`
+  (which starts all four DBs) cannot pass until `docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`
+  and `*.data.mcr.microsoft.com` are allowlisted (then plain `docker pull` works for every image and the
+  ECR retag workaround / Ryuk-disable are no longer needed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for this Kotlin/Gradle library and documents the non-obvious Cloud caveats in `AGENTS.md` under `## Cursor Cloud specific instructions`.

No production/library code is changed — this PR only adds durable setup notes for future Cloud agents.

## Environment setup performed (captured in the VM snapshot)
- Installed **JDK 11 and 17** (Gradle requires a JDK 11 toolchain; default `java` is 21, which Gradle auto-detects the 11 toolchain alongside).
- Installed **Docker** (configured with `fuse-overlayfs` + containerd snapshotter disabled for this VM) for Testcontainers-based integration tests.

## Verification
- ✅ `./gradlew compileTestKotlin` — all modules compile.
- ✅ `./gradlew apiCheck` — binary-compatibility/API lint passes.
- ✅ PostgreSQL integration test (real `postgres:latest` Testcontainer) executed the full reactive CRUD flow (insert/update/select/delete via Vert.x SQL Client + Exposed) — **2 tests, 0 failures**.

## Known egress limitation
Image blob CDNs for Docker Hub (`docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`) and MCR (`*.data.mcr.microsoft.com`) are blocked by the network allowlist; only `public.ecr.aws` blobs are reachable. PostgreSQL and MySQL images are obtainable via the AWS ECR public mirror, but Oracle (`gvenzl/oracle-free`) and MSSQL images are not, so the full 4-database `./gradlew test` / `check` cannot pass until those two blob domains are allowlisted. Details and the ECR-mirror workaround are documented in `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7aafc92-3a98-417f-90a2-747b3e3b2ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7aafc92-3a98-417f-90a2-747b3e3b2ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

