### PR TITLE
docs: add Cursor Cloud specific environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
 See [Copilot instructions](.github/copilot-instructions.md) for this repository.
 
 Organization-wide standards and open-source library map: [@huanshankeji/.github general agent instructions](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md).
+
+## Cursor Cloud specific instructions
+
+This is a Kotlin/JVM Gradle library (Exposed + Vert.x SQL Client). Standard build/lint/test commands live in [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (`./gradlew assemble`, `./gradlew apiCheck`, `./gradlew check`, `./gradlew test`). Notes below are only the non-obvious environment caveats.
+
+- **JDK 11 is required to compile.** The Kotlin toolchain is pinned to `kotlin.jvmToolchain(11)`, but no toolchain download repository is configured, so Gradle needs a locally-installed JDK 11 (it auto-detects `/usr/lib/jvm`). The Gradle daemon itself runs fine on the default JDK 21. Without a JDK 11 present, builds fail with "Cannot find a Java installation ... matching languageVersion=11".
+- **Integration tests need Docker.** `./gradlew check` / `./gradlew test` run the `integrated` module against Testcontainers (PostgreSQL, MySQL, Oracle, MSSQL). Start the daemon with `sudo service docker start` before running tests (it is not started automatically). Docker is configured with the `fuse-overlayfs` storage driver and the containerd snapshotter disabled.
+- **Docker Hub blob egress is restricted.** Registry endpoints resolve, but image layer/config blobs are served from `docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`, which is blocked by the default egress policy — so Testcontainers cannot pull `postgres`/`mysql`/`gvenzl/oracle-free` images. That S3 host must be added to the network allowlist to run the full Testcontainers suite. `mcr.microsoft.com` (MSSQL image) is reachable.
+- **Quick end-to-end check without Docker:** a local PostgreSQL works for the core CRUD flow. Start it with `sudo service postgresql start` and create the role/db expected by `integrated` `Examples` (`evscConfig`): user `user`, password `password`, database `database` (owned by `user`) on `localhost:5432`. The library's CRUD examples (`crudWithStatements` / `crudExtensions` in `integrated/.../Examples.kt`) then run against it directly, bypassing Testcontainers.
+- **Do not run `./gradlew apiDump` automatically** — see `.github/copilot-instructions.md` for the API-change workflow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cursor Cloud development environment for this Kotlin/JVM Gradle library (Exposed + Vert.x SQL Client). The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing non-obvious environment caveats discovered during setup.

## Environment setup performed

- Installed **JDK 11** (required by the pinned `kotlin.jvmToolchain(11)`; no toolchain download repo is configured so a local JDK 11 is needed). Gradle daemon still runs on JDK 21.
- Installed **Docker** (fuse-overlayfs storage driver, containerd snapshotter disabled) for the Testcontainers-based integration tests.
- Installed a local **PostgreSQL 16** and created the `user`/`password`/`database` role+db expected by the `integrated` `Examples` config, to demonstrate the library end-to-end without pulling container images.

## Verification

- ✅ `./gradlew assemble apiCheck` — builds all 8 modules and passes binary-compatibility (lint).
- ✅ Ran the library's CRUD examples (`crudWithStatements` / `crudExtensions`) against local PostgreSQL via a temporary Kotest spec (not committed): 2 tests passed, 0 skipped, 0 failures — reactive insert/update/select/delete roundtrip works.
- ⚠️ Full `./gradlew check` / `./gradlew test` (Testcontainers) is blocked in this environment: Docker Hub image blobs are served from `docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`, which the default egress policy resets. That host must be allowlisted to pull `postgres`/`mysql`/`gvenzl/oracle-free`.

Demonstration log:
[env_demo_local_pg.log](https://cursor.com/artifacts/c/art-52b2b88c-da72-451f-8e63-6c8bffbd9506)

## Update script

`./gradlew --version` (provisions the Gradle wrapper distribution; minimal and idempotent). System dependencies (JDK 11, Docker, PostgreSQL) are provided via the VM snapshot, and service startup is documented in `AGENTS.md` rather than the update script.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c575291-3fbc-4ad8-9a18-d408ebb35a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c575291-3fbc-4ad8-9a18-d408ebb35a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

